### PR TITLE
Enable proxy forwarding for gRPC HTTP2 traffic for TypeDB

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,44 @@
+name: LocalStack TypeDB Extension Tests
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  LOCALSTACK_DISABLE_EVENTS: "1"
+  LOCALSTACK_AUTH_TOKEN: ${{ secrets.TEST_LOCALSTACK_AUTH_TOKEN }}
+
+jobs:
+  integration-tests:
+    name: Run Integration Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup LocalStack and extension
+        run: |
+          cd localstack-typedb
+
+          docker pull localstack/localstack-pro &
+          docker pull typedb/typedb &
+          pip install localstack
+
+          make install
+          make dist
+          localstack extensions -v install file://$(ls ./dist/localstack_typedb-*.tar.gz)
+
+          DEBUG=1 localstack start -d
+          localstack wait
+
+      - name: Run integration tests
+        run: |
+          cd localstack-typedb
+          make test
+
+      - name: Print logs
+        if: always()
+        run: |
+          localstack logs
+          localstack stop

--- a/localstack-typedb/localstack_typedb/extension.py
+++ b/localstack-typedb/localstack_typedb/extension.py
@@ -1,4 +1,5 @@
 from localstack_typedb.utils.docker import ProxiedDockerContainerExtension
+from rolo import Request
 
 
 class TypeDbExtension(ProxiedDockerContainerExtension):
@@ -9,5 +10,13 @@ class TypeDbExtension(ProxiedDockerContainerExtension):
 
     def __init__(self):
         super().__init__(
-            image_name=self.DOCKER_IMAGE, container_ports=[8000, 1729], host=self.HOST
+            image_name=self.DOCKER_IMAGE,
+            container_ports=[8000, 1729],
+            host=self.HOST,
+            request_to_port_router=self.request_to_port_router,
         )
+
+    def request_to_port_router(self, request: Request):
+        print("!REQ", request, request.headers, request.data)
+        print("!request", request, request.__dict__)
+        return 1729

--- a/localstack-typedb/localstack_typedb/extension.py
+++ b/localstack-typedb/localstack_typedb/extension.py
@@ -17,6 +17,5 @@ class TypeDbExtension(ProxiedDockerContainerExtension):
         )
 
     def request_to_port_router(self, request: Request):
-        print("!REQ target port", request, request.data)
-        # print("!request", request, request.__dict__)
+        # TODO add REST API / gRPC routing based on request
         return 1729

--- a/localstack-typedb/localstack_typedb/extension.py
+++ b/localstack-typedb/localstack_typedb/extension.py
@@ -17,6 +17,6 @@ class TypeDbExtension(ProxiedDockerContainerExtension):
         )
 
     def request_to_port_router(self, request: Request):
-        print("!REQ", request, request.headers, request.data)
-        print("!request", request, request.__dict__)
+        print("!REQ target port", request, request.data)
+        # print("!request", request, request.__dict__)
         return 1729

--- a/localstack-typedb/localstack_typedb/utils/docker.py
+++ b/localstack-typedb/localstack_typedb/utils/docker.py
@@ -1,9 +1,11 @@
 import queue
 import re
 import logging
+import socket
 from functools import cache
 from typing import Callable
 
+from localstack.runtime import events
 from twisted.internet import reactor
 from twisted.web._http2 import H2Stream
 
@@ -13,18 +15,12 @@ from localstack import config
 from localstack.services.edge import ROUTER
 from localstack.utils.patch import patch
 from localstack.utils.strings import to_str, to_bytes
-from rolo import Response
-from rolo.proxy import Proxy
 from localstack.utils.docker_utils import DOCKER_CLIENT
 from localstack.extensions.api import Extension, http
 from localstack.http import Request
 from localstack.utils.container_utils.container_client import PortMappings
 from localstack.utils.net import get_addressable_container_host
 from localstack.utils.sync import retry
-from rolo.serving.twisted import (
-    TwistedRequestAdapter,
-    to_flat_header_list,
-)
 from twisted.web._http2 import H2Connection
 from twisted.web.server import NOT_DONE_YET
 
@@ -51,9 +47,7 @@ class ProxiedDockerContainerExtension(Extension):
     """Optional path on which to expose the container endpoints."""
 
     request_to_port_router: Callable[[Request], int] | None
-    # TODO: currently not yet used ...
-    tcp_proxy_ports: list | None
-    tcp_proxies: list[int]
+    """Callable that returns the target port for a given request, for routing purposes"""
 
     def __init__(
         self,
@@ -63,26 +57,15 @@ class ProxiedDockerContainerExtension(Extension):
         path: str | None = None,
         container_name: str | None = None,
         request_to_port_router: Callable[[Request], int] | None = None,
-        # tcp_proxy_ports: list[int] | None = None,
     ):
         self.image_name = image_name
         self.container_ports = container_ports
         self.host = host
         self.path = path
         self.container_name = container_name
-        # self.tcp_proxy_ports = tcp_proxy_ports
-        # self.tcp_proxies = []
         self.request_to_port_router = request_to_port_router
 
     def update_gateway_routes(self, router: http.Router[http.RouteHandler]):
-        # resource = RuleAdapter(ProxyResource(self))
-        # if self.host:
-        #     resource = WithHost(self.host, [resource])
-        # if self.path:
-        #     raise NotImplementedError(
-        #         "Path-based routing not yet implemented for this extension"
-        #     )
-        # router.add(resource)
         if self.path:
             raise NotImplementedError(
                 "Path-based routing not yet implemented for this extension"
@@ -94,6 +77,7 @@ class ProxiedDockerContainerExtension(Extension):
             defaults={},
             strict_slashes=False,
         )
+        _apply_patches(self)
 
     def on_platform_shutdown(self):
         self._remove_container()
@@ -155,89 +139,64 @@ class ProxiedDockerContainerExtension(Extension):
         )
 
 
-# class Http2EnabledRequestsClient(SimpleRequestsClient):
-#     def __init__(self, *args, **kwargs):
-#         import httpx
-#
-#         super().__init__(*args, **kwargs)
-#         # proxies = httpx._utils.get_environment_proxies()
-#         # print("!proxies", proxies)
-#         client = httpx.Client(http2=True)
-#         self.session.mount("http://", client)
+class TcpForwarder:
+    def __init__(self, port: int, host: str = "localhost"):
+        self.port = port
+        self.host = host
+        self._buffer_size = 1024
+        self._socket = None
+        self.connect()
+
+    def connect(self):
+        if not self._socket:
+            self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self._socket.connect((self.host, self.port))
+
+    def receive_loop(self, callback):
+        self.connect()
+        while True:
+            data = self._socket.recv(self._buffer_size)
+            callback(data)
+            if not data:
+                break
+
+    def send(self, data):
+        self._socket.sendall(data)
 
 
-# @patch(WebsocketResourceDecorator.render)
-def render(fn, self, request):
-    from rolo import Response
-    from localstack.utils.strings import to_str
-    from werkzeug.datastructures.headers import Headers
+def _apply_patches(extension):
+    @patch(H2Connection.connectionMade)
+    def _connectionMade(fn, self, *args, **kwargs):
+        extension.start_container()
 
-    def _processH2Request(request: Request):
-        def handler(req, *args):
-            print("!!_processH2Request 1234", type(req), req.__dict__)
-            response = Response(status=101)
-            gateway = self.original._application.gateway
-            req.headers = Headers(
-                {
-                    to_str(k): to_str(v)
-                    for k, v in to_flat_header_list(req.requestHeaders)
-                }
-            )
-            req.path = to_str(req.path)
-            req.host = req.headers.get("Host") or "localhost"
-            req.content_encoding = None
-            req.environ = {"RAW_URI": to_str(req.uri)}
-            req.shallow = False
-            req.values = {}
-            req.user_agent = ""
-            req.data = req.content.read()
-            print("!req details", req.__dict__)
-            result = gateway.process(req, response)
-            print("!gateway process result", result, response.status_code)
+        self._ls_forwarder = TcpForwarder(1729)
+        print("!!self.transport", self.transport, self.transport.__dict__)
 
-        # WSGIResource also dispatches requests through the threadpool
-        self.original._threadpool.callInThread(handler, request)
+        def _print(data):
+            print("!RETURN RESPONSE received upstream", data)
+            self.transport.write(data)
 
-    print("!!render req patched", request, request.__dict__, request.clientproto)
-    if request.clientproto == b"HTTP/2":
-        _processH2Request(request)
-        return NOT_DONE_YET
+        reactor.getThreadPool().callInThread(self._ls_forwarder.receive_loop, _print)
 
-    return fn(self, request)
+    @patch(H2Connection.dataReceived)
+    def _dataReceived(fn, self, data, *args, **kwargs):
+        forwarder = getattr(self, "_ls_forwarder", None)
+        if not forwarder:
+            return fn(self, data, *args, **kwargs)
+        print("!!RECEIVED FROM client", data)
+        forwarder.send(data)
 
 
-# class H2Request(TwistedRequest):
-#     def __init__(self, stream: H2Stream):
-#         super().__init__(stream)
-#         self.stream = stream
-#         print("!H2Request", stream)
-#
-#     def connectionLost(self, reason):
-#         print("!H2Request.connectionLost", reason)
-#
-#     def handleContentChunk(self, data):
-#         print("!H2Request.handleContentChunk", data)
-
-
-# @patch(H2Stream.__init__)
-def h2stream_init(fn, self, *args, **kwargs):
-    fn(self, *args, **kwargs)
-    self._request = H2Request(self)
-
-
-@patch(H2Connection._requestReceived)
+# @patch(H2Connection._requestReceived)
 def _requestReceived(fn, self, event, *args, **kwargs):
-    # print("!!_requestReceived 13", event, self)
-    result = fn(self, event, *args, **kwargs)
-
-    stream = self.streams[event.stream_id]
+    # call upstream function
+    fn(self, event, *args, **kwargs)
 
     headers = {to_str(k): to_str(v) for k, v in event.headers}
     method = headers[":method"]
     path = headers[":path"]
     host = headers[":authority"]
     headers = {k: v for k, v in headers.items() if not k.startswith(":")}
-    # print("!event", event, method, path, headers)
     headers["Host"] = host
 
     request = Request(
@@ -246,15 +205,12 @@ def _requestReceived(fn, self, event, *args, **kwargs):
         headers=headers,
         body=None,
     )
-    request.h2_stream = stream
+    request.h2_stream = self.streams[event.stream_id]
     matcher = ROUTER.url_map.bind(server_name=request.host)
-    # print("!request.host", request.host, request)
     handler, args = matcher.match(request.path, method=request.method)
-    # print("!MATCHER", matcher, handler, args)
-    response = ROUTER.dispatcher(request, handler, args)
-    # print("!ROUTER.dispatcher", response)
+    ROUTER.dispatcher(request, handler, args)
 
-    return result
+    return NOT_DONE_YET
 
 
 def get_environment_proxies(*args, **kwargs):
@@ -280,215 +236,79 @@ class ProxyResource:
         self.extension = extension
 
     def __call__(self, request: Request, path, *args, **kwargs):
-        print("!request in __call__", path, type(request))
-        # print("!request.__dict__", request.__dict__)
         stream = getattr(request, "h2_stream", None)
         if not isinstance(stream, H2Stream):
             return
 
         self.extension.start_container()
 
-        # assert isinstance(stream, H2Stream)
         stream.h2_client = httpx.Client(http2=True, http1=False)
-        # h2_request = stream.h2_client.stream
-
         msg_queue = queue.Queue()
 
         def _data_generator():
             while True:
                 try:
-                    message = msg_queue.get(timeout=5)
+                    message = msg_queue.get(timeout=3)
                 except queue.Empty:
-                    yield b""
-                    return
+                    if events.infra_stopping.is_set():
+                        return
+                    continue
                 if message is None:
                     break
-                print("!dequeued message", message)
                 yield message
-                # stream._send100Continue()
                 if message == b"":
                     break
+                # stream._send100Continue()
+                # return
 
         def _receive_chunk(data, flowControlledLength):
-            print("!receive_chunk", self, data, flowControlledLength)
+            print("!_receive_chunk", data, len(data), flowControlledLength)
             msg_queue.put(data)
-            return
-
-            # result = stream.h2_client.request(
-            #     method=request.method,
-            #     path=path,
-            #     data=data,
-            #     headers=request.headers,
-            # )
-            request.data = data
-            result = self._forward_http2_request(request, forward_path=to_str(path))
-
-            print("!receive_chunk response", result, result.headers)
-            headers = [
-                (to_bytes(k), to_bytes(v)) for k, v in dict(result.headers).items()
-            ]
-
-            # headers = {k: v for k, v in dict(response.headers).items() if not k.startswith(":")}
-            headers.insert(0, (b":status", to_bytes(str(result.status_code))))
-
-            # note: using `send_headers(..)` instead of ,
-            print("!!proxied", result, headers)
-            h2_conn = stream._conn
-            # h2_conn.conn.send_headers(stream.streamID, headers)
-            # h2_conn._tryToWriteControlData()
-
-            # stream.writeHeaders(
-            #     None,
-            #     code=to_bytes(str(result.status_code)),
-            #     reason=None,
-            #     headers=headers,
-            # )
-
-            stream.write(result.data)
+            stream._conn.openStreamWindow(stream.streamID, flowControlledLength)
+            print("!_receive_chunk DONE", flowControlledLength)
 
         def _request_complete():
-            print("!request_complete", self)
             msg_queue.put(None)
             # return _request_complete_orig()
-
-        # def _handle_data(response):
-        #     def receiveDataChunk(self, data, flowControlledLength):
 
         stream.receiveDataChunk = _receive_chunk
         _request_complete_orig = stream.requestComplete
         stream.requestComplete = _request_complete
 
-        target_url = f"{self._get_target_url(request)}/{path}"
-        print("!target_url", target_url, request.method)
         def _run_request():
-            print("!run_request", to_str(request.method), target_url, dict(request.headers))
             headers = dict(request.headers)
             headers.pop("content-length", None)
-            result = stream.h2_client.request(
+            target_url = f"{self._get_target_url(request)}/{path}"
+            streaming_response = stream.h2_client.stream(
                 method=to_str(request.method),
                 url=target_url,
                 content=_data_generator(),
                 headers=headers,
             )
-            print("!result123 tmp", result, result.__dict__)
 
-            res_headers = [
-                (to_bytes(k), to_bytes(v)) for k, v in dict(result.headers).items()
-            ]
-            stream.writeHeaders(
-                None,
-                code=to_bytes(str(result.status_code)),
-                reason=None,
-                headers=res_headers,
-            )
+            with streaming_response as response:
+                res_headers = [
+                    (to_bytes(k), to_bytes(v))
+                    for k, v in dict(response.headers).items()
+                ]
+                stream.writeHeaders(
+                    None,
+                    code=to_bytes(str(response.status_code)),
+                    reason=None,
+                    headers=res_headers,
+                )
+                for data in response.iter_bytes():
+                    print("!!!!data123", data)
+                    stream.write(data)
 
-            print("!write response content")
-            stream.write(result.content)
-            print("!ALL DONE")
-            # _request_complete_orig()
-            # stream._conn._tryToWriteControlData()
             stream.requestDone(request)
 
         reactor.getThreadPool().callInThread(_run_request)
-
-        # result = self._forward_http2_request(request, forward_path=to_str(request.path))
-        # assert len(result.data) == int(result.headers["content-length"])
-        # headers = [
-        #     (to_bytes(k), to_bytes(v)) for k, v in dict(result.headers).items()
-        # ]
-        # print("!!proxied", result, headers)
-        # stream.writeHeaders(
-        #     None,
-        #     code=to_bytes(str(result.status_code)),
-        #     reason=None,
-        #     headers=headers,
-        # )
-        # stream.write(result.data)
-
-    def __call2__(self, request: TwistedRequestAdapter, path, *args, **kwargs):
-        assert isinstance(request, TwistedRequestAdapter)
-        self.extension.start_container()
-
-        # print("!CALL", request, path, type(request), request.__dict__)
-        result = self._forward_http2_request(request, forward_path=to_str(request.path))
-        # print("!!request.channel", request.channel, result, result.data)
-        if isinstance(request.channel, H2Stream):
-            assert len(result.data) == int(result.headers["content-length"])
-            headers = [
-                (to_bytes(k), to_bytes(v)) for k, v in dict(result.headers).items()
-            ]
-            request.channel.writeHeaders(
-                None,
-                code=to_bytes(str(result.status_code)),
-                reason=None,
-                headers=headers,
-            )
-            request.channel.write(result.data)
-            # request.channel._send100Continue()
-            request.channel.requestDone(None)
-
-    # @route("/<path:path>")
-    # def index(self, request: Request, path: str, *args, **kwargs):
-    #     return self._proxy_request(request, forward_path=f"/{path}")
-
-    def _proxy_request(self, request: Request, forward_path: str, *args, **kwargs):
-        self.extension.start_container()
-
-        print("!REQ", request, request.__dict__)
-        if request.environ.get("SERVER_PROTOCOL") == "HTTP/2":
-            return self._proxy_http2_request(request, forward_path=forward_path)
-
-        # create proxy
-        base_url = self._get_target_url(request)
-        proxy = Proxy(forward_base_url=base_url)
-
-        # update content length (may have changed due to content compression)
-        if request.method not in ("GET", "OPTIONS"):
-            request.headers["Content-Length"] = str(len(request.data))
-
-        # # make sure we're forwarding the correct Host header
-        # request.headers["Host"] = f"localhost:{port}"
-
-        # forward the request to the target
-        result = proxy.forward(request, forward_path=forward_path)
-
-        return result
-
-    def _proxy_http2_request(
-        self, request: Request, forward_path: str, *args, **kwargs
-    ):
-        result = self._forward_http2_request(request, forward_path=forward_path)
-        return result
-
-    def _forward_http2_request(
-        self, request: Request, forward_path: str, *args, **kwargs
-    ):
-        forward_path = (
-            f"/{forward_path}" if not forward_path.startswith("/") else forward_path
-        )
-        with httpx.Client(http2=True, http1=False) as client:
-            target_url = f"{self._get_target_url(request)}{forward_path}"
-            # print("!request", request.method, target_url, request.headers, request.data)
-            print("!target_url", target_url)
-            response = client.request(
-                method=to_str(request.method),
-                url=target_url,
-                headers=request.headers,
-                content=request.data,
-            )
-            print("!target_url", target_url, response.content, response.status_code)
-            result = Response(
-                response=response.content,
-                status=response.status_code,
-                headers=dict(response.headers),
-            )
-            return result
 
     def _get_target_url(self, request: Request) -> str:
         port = self.extension.container_ports[0]
         if self.extension.request_to_port_router:
             port = self.extension.request_to_port_router(request)
-
         container_host = get_addressable_container_host()
         base_url = f"http://{container_host}:{port}"
         return base_url

--- a/localstack-typedb/localstack_typedb/utils/docker.py
+++ b/localstack-typedb/localstack_typedb/utils/docker.py
@@ -1,11 +1,18 @@
+import queue
 import re
 import logging
 from functools import cache
 from typing import Callable
 
+from twisted.internet import reactor
+from twisted.web._http2 import H2Stream
+
 import requests
 import httpx._utils
 from localstack import config
+from localstack.services.edge import ROUTER
+from localstack.utils.patch import patch
+from localstack.utils.strings import to_str, to_bytes
 from rolo import Response
 from rolo.proxy import Proxy
 from localstack.utils.docker_utils import DOCKER_CLIENT
@@ -14,6 +21,12 @@ from localstack.http import Request
 from localstack.utils.container_utils.container_client import PortMappings
 from localstack.utils.net import get_addressable_container_host
 from localstack.utils.sync import retry
+from rolo.serving.twisted import (
+    TwistedRequestAdapter,
+    to_flat_header_list,
+)
+from twisted.web._http2 import H2Connection
+from twisted.web.server import NOT_DONE_YET
 
 LOG = logging.getLogger(__name__)
 LOG.setLevel(logging.DEBUG if config.DEBUG else logging.INFO)
@@ -46,11 +59,11 @@ class ProxiedDockerContainerExtension(Extension):
         self,
         image_name: str,
         container_ports: list[int],
-        tcp_proxy_ports: list[int] | None = None,
         host: str | None = None,
         path: str | None = None,
         container_name: str | None = None,
         request_to_port_router: Callable[[Request], int] | None = None,
+        # tcp_proxy_ports: list[int] | None = None,
     ):
         self.image_name = image_name
         self.container_ports = container_ports
@@ -153,6 +166,97 @@ class ProxiedDockerContainerExtension(Extension):
 #         self.session.mount("http://", client)
 
 
+# @patch(WebsocketResourceDecorator.render)
+def render(fn, self, request):
+    from rolo import Response
+    from localstack.utils.strings import to_str
+    from werkzeug.datastructures.headers import Headers
+
+    def _processH2Request(request: Request):
+        def handler(req, *args):
+            print("!!_processH2Request 1234", type(req), req.__dict__)
+            response = Response(status=101)
+            gateway = self.original._application.gateway
+            req.headers = Headers(
+                {
+                    to_str(k): to_str(v)
+                    for k, v in to_flat_header_list(req.requestHeaders)
+                }
+            )
+            req.path = to_str(req.path)
+            req.host = req.headers.get("Host") or "localhost"
+            req.content_encoding = None
+            req.environ = {"RAW_URI": to_str(req.uri)}
+            req.shallow = False
+            req.values = {}
+            req.user_agent = ""
+            req.data = req.content.read()
+            print("!req details", req.__dict__)
+            result = gateway.process(req, response)
+            print("!gateway process result", result, response.status_code)
+
+        # WSGIResource also dispatches requests through the threadpool
+        self.original._threadpool.callInThread(handler, request)
+
+    print("!!render req patched", request, request.__dict__, request.clientproto)
+    if request.clientproto == b"HTTP/2":
+        _processH2Request(request)
+        return NOT_DONE_YET
+
+    return fn(self, request)
+
+
+# class H2Request(TwistedRequest):
+#     def __init__(self, stream: H2Stream):
+#         super().__init__(stream)
+#         self.stream = stream
+#         print("!H2Request", stream)
+#
+#     def connectionLost(self, reason):
+#         print("!H2Request.connectionLost", reason)
+#
+#     def handleContentChunk(self, data):
+#         print("!H2Request.handleContentChunk", data)
+
+
+# @patch(H2Stream.__init__)
+def h2stream_init(fn, self, *args, **kwargs):
+    fn(self, *args, **kwargs)
+    self._request = H2Request(self)
+
+
+@patch(H2Connection._requestReceived)
+def _requestReceived(fn, self, event, *args, **kwargs):
+    # print("!!_requestReceived 13", event, self)
+    result = fn(self, event, *args, **kwargs)
+
+    stream = self.streams[event.stream_id]
+
+    headers = {to_str(k): to_str(v) for k, v in event.headers}
+    method = headers[":method"]
+    path = headers[":path"]
+    host = headers[":authority"]
+    headers = {k: v for k, v in headers.items() if not k.startswith(":")}
+    # print("!event", event, method, path, headers)
+    headers["Host"] = host
+
+    request = Request(
+        method=method,
+        path=path,
+        headers=headers,
+        body=None,
+    )
+    request.h2_stream = stream
+    matcher = ROUTER.url_map.bind(server_name=request.host)
+    # print("!request.host", request.host, request)
+    handler, args = matcher.match(request.path, method=request.method)
+    # print("!MATCHER", matcher, handler, args)
+    response = ROUTER.dispatcher(request, handler, args)
+    # print("!ROUTER.dispatcher", response)
+
+    return result
+
+
 def get_environment_proxies(*args, **kwargs):
     # small patch to fix handling of proxy keys like 'all://*[::1]'
     result = get_environment_proxies_orig(*args, **kwargs)
@@ -175,8 +279,153 @@ class ProxyResource:
     def __init__(self, extension: ProxiedDockerContainerExtension):
         self.extension = extension
 
-    def __call__(self, request, path, *args, **kwargs):
-        print("!CALL", request, path, type(request), request.__dict__)
+    def __call__(self, request: Request, path, *args, **kwargs):
+        print("!request in __call__", path, type(request))
+        # print("!request.__dict__", request.__dict__)
+        stream = getattr(request, "h2_stream", None)
+        if not isinstance(stream, H2Stream):
+            return
+
+        self.extension.start_container()
+
+        # assert isinstance(stream, H2Stream)
+        stream.h2_client = httpx.Client(http2=True, http1=False)
+        # h2_request = stream.h2_client.stream
+
+        msg_queue = queue.Queue()
+
+        def _data_generator():
+            while True:
+                try:
+                    message = msg_queue.get(timeout=5)
+                except queue.Empty:
+                    yield b""
+                    return
+                if message is None:
+                    break
+                print("!dequeued message", message)
+                yield message
+                # stream._send100Continue()
+                if message == b"":
+                    break
+
+        def _receive_chunk(data, flowControlledLength):
+            print("!receive_chunk", self, data, flowControlledLength)
+            msg_queue.put(data)
+            return
+
+            # result = stream.h2_client.request(
+            #     method=request.method,
+            #     path=path,
+            #     data=data,
+            #     headers=request.headers,
+            # )
+            request.data = data
+            result = self._forward_http2_request(request, forward_path=to_str(path))
+
+            print("!receive_chunk response", result, result.headers)
+            headers = [
+                (to_bytes(k), to_bytes(v)) for k, v in dict(result.headers).items()
+            ]
+
+            # headers = {k: v for k, v in dict(response.headers).items() if not k.startswith(":")}
+            headers.insert(0, (b":status", to_bytes(str(result.status_code))))
+
+            # note: using `send_headers(..)` instead of ,
+            print("!!proxied", result, headers)
+            h2_conn = stream._conn
+            # h2_conn.conn.send_headers(stream.streamID, headers)
+            # h2_conn._tryToWriteControlData()
+
+            # stream.writeHeaders(
+            #     None,
+            #     code=to_bytes(str(result.status_code)),
+            #     reason=None,
+            #     headers=headers,
+            # )
+
+            stream.write(result.data)
+
+        def _request_complete():
+            print("!request_complete", self)
+            msg_queue.put(None)
+            # return _request_complete_orig()
+
+        # def _handle_data(response):
+        #     def receiveDataChunk(self, data, flowControlledLength):
+
+        stream.receiveDataChunk = _receive_chunk
+        _request_complete_orig = stream.requestComplete
+        stream.requestComplete = _request_complete
+
+        target_url = f"{self._get_target_url(request)}/{path}"
+        print("!target_url", target_url, request.method)
+        def _run_request():
+            print("!run_request", to_str(request.method), target_url, dict(request.headers))
+            headers = dict(request.headers)
+            headers.pop("content-length", None)
+            result = stream.h2_client.request(
+                method=to_str(request.method),
+                url=target_url,
+                content=_data_generator(),
+                headers=headers,
+            )
+            print("!result123 tmp", result, result.__dict__)
+
+            res_headers = [
+                (to_bytes(k), to_bytes(v)) for k, v in dict(result.headers).items()
+            ]
+            stream.writeHeaders(
+                None,
+                code=to_bytes(str(result.status_code)),
+                reason=None,
+                headers=res_headers,
+            )
+
+            print("!write response content")
+            stream.write(result.content)
+            print("!ALL DONE")
+            # _request_complete_orig()
+            # stream._conn._tryToWriteControlData()
+            stream.requestDone(request)
+
+        reactor.getThreadPool().callInThread(_run_request)
+
+        # result = self._forward_http2_request(request, forward_path=to_str(request.path))
+        # assert len(result.data) == int(result.headers["content-length"])
+        # headers = [
+        #     (to_bytes(k), to_bytes(v)) for k, v in dict(result.headers).items()
+        # ]
+        # print("!!proxied", result, headers)
+        # stream.writeHeaders(
+        #     None,
+        #     code=to_bytes(str(result.status_code)),
+        #     reason=None,
+        #     headers=headers,
+        # )
+        # stream.write(result.data)
+
+    def __call2__(self, request: TwistedRequestAdapter, path, *args, **kwargs):
+        assert isinstance(request, TwistedRequestAdapter)
+        self.extension.start_container()
+
+        # print("!CALL", request, path, type(request), request.__dict__)
+        result = self._forward_http2_request(request, forward_path=to_str(request.path))
+        # print("!!request.channel", request.channel, result, result.data)
+        if isinstance(request.channel, H2Stream):
+            assert len(result.data) == int(result.headers["content-length"])
+            headers = [
+                (to_bytes(k), to_bytes(v)) for k, v in dict(result.headers).items()
+            ]
+            request.channel.writeHeaders(
+                None,
+                code=to_bytes(str(result.status_code)),
+                reason=None,
+                headers=headers,
+            )
+            request.channel.write(result.data)
+            # request.channel._send100Continue()
+            request.channel.requestDone(None)
 
     # @route("/<path:path>")
     # def index(self, request: Request, path: str, *args, **kwargs):
@@ -208,35 +457,32 @@ class ProxyResource:
     def _proxy_http2_request(
         self, request: Request, forward_path: str, *args, **kwargs
     ):
-        import traceback
+        result = self._forward_http2_request(request, forward_path=forward_path)
+        return result
 
-        print("!request in ls-ext", request)
-        print("".join(traceback.format_stack()))
-
+    def _forward_http2_request(
+        self, request: Request, forward_path: str, *args, **kwargs
+    ):
+        forward_path = (
+            f"/{forward_path}" if not forward_path.startswith("/") else forward_path
+        )
         with httpx.Client(http2=True, http1=False) as client:
             target_url = f"{self._get_target_url(request)}{forward_path}"
+            # print("!request", request.method, target_url, request.headers, request.data)
             print("!target_url", target_url)
             response = client.request(
-                method=request.method,
+                method=to_str(request.method),
                 url=target_url,
                 headers=request.headers,
                 content=request.data,
             )
+            print("!target_url", target_url, response.content, response.status_code)
             result = Response(
                 response=response.content,
                 status=response.status_code,
                 headers=dict(response.headers),
             )
-            content = request.stream.read()
-            print(
-                "!response.headers",
-                dict(response.headers),
-                response.content,
-                response.status_code,
-                content,
-            )
-            # request.write(b'foo response')
-            # return result
+            return result
 
     def _get_target_url(self, request: Request) -> str:
         port = self.extension.container_ports[0]

--- a/localstack-typedb/localstack_typedb/utils/docker.py
+++ b/localstack-typedb/localstack_typedb/utils/docker.py
@@ -1,14 +1,16 @@
 import re
 import logging
 from functools import cache
+from typing import Callable
 
 import requests
+import httpx._utils
 from localstack import config
+from rolo import Response
 from rolo.proxy import Proxy
 from localstack.utils.docker_utils import DOCKER_CLIENT
 from localstack.extensions.api import Extension, http
-from rolo.router import RuleAdapter, WithHost
-from localstack.http import Request, route
+from localstack.http import Request
 from localstack.utils.container_utils.container_client import PortMappings
 from localstack.utils.net import get_addressable_container_host
 from localstack.utils.sync import retry
@@ -35,6 +37,7 @@ class ProxiedDockerContainerExtension(Extension):
     path: str | None
     """Optional path on which to expose the container endpoints."""
 
+    request_to_port_router: Callable[[Request], int] | None
     # TODO: currently not yet used ...
     tcp_proxy_ports: list | None
     tcp_proxies: list[int]
@@ -47,24 +50,37 @@ class ProxiedDockerContainerExtension(Extension):
         host: str | None = None,
         path: str | None = None,
         container_name: str | None = None,
+        request_to_port_router: Callable[[Request], int] | None = None,
     ):
         self.image_name = image_name
         self.container_ports = container_ports
         self.host = host
         self.path = path
         self.container_name = container_name
-        self.tcp_proxy_ports = tcp_proxy_ports
-        self.tcp_proxies = []
+        # self.tcp_proxy_ports = tcp_proxy_ports
+        # self.tcp_proxies = []
+        self.request_to_port_router = request_to_port_router
 
     def update_gateway_routes(self, router: http.Router[http.RouteHandler]):
-        resource = RuleAdapter(ProxyResource(self))
-        if self.host:
-            resource = WithHost(self.host, [resource])
+        # resource = RuleAdapter(ProxyResource(self))
+        # if self.host:
+        #     resource = WithHost(self.host, [resource])
+        # if self.path:
+        #     raise NotImplementedError(
+        #         "Path-based routing not yet implemented for this extension"
+        #     )
+        # router.add(resource)
         if self.path:
             raise NotImplementedError(
                 "Path-based routing not yet implemented for this extension"
             )
-        router.add(resource)
+        router.add(
+            path="/<path:path>",
+            host=self.host,
+            endpoint=ProxyResource(self),
+            defaults={},
+            strict_slashes=False,
+        )
 
     def on_platform_shutdown(self):
         self._remove_container()
@@ -95,12 +111,13 @@ class ProxiedDockerContainerExtension(Extension):
         main_port = self.container_ports[0]
         container_host = get_addressable_container_host()
 
-        def _ping_api():
+        def _ping_endpoint():
+            # TODO: allow defining a custom healthcheck endpoint ...
             response = requests.get(f"http://{container_host}:{main_port}/")
             assert response.ok
 
         try:
-            retry(_ping_api, retries=40, sleep=1)
+            retry(_ping_endpoint, retries=40, sleep=1)
         except Exception as e:
             LOG.info("Failed to connect to container %s: %s", container_name, e)
             self._remove_container()
@@ -125,6 +142,28 @@ class ProxiedDockerContainerExtension(Extension):
         )
 
 
+# class Http2EnabledRequestsClient(SimpleRequestsClient):
+#     def __init__(self, *args, **kwargs):
+#         import httpx
+#
+#         super().__init__(*args, **kwargs)
+#         # proxies = httpx._utils.get_environment_proxies()
+#         # print("!proxies", proxies)
+#         client = httpx.Client(http2=True)
+#         self.session.mount("http://", client)
+
+
+def get_environment_proxies(*args, **kwargs):
+    # small patch to fix handling of proxy keys like 'all://*[::1]'
+    result = get_environment_proxies_orig(*args, **kwargs)
+    return {k: v for k, v in result.items() if "[::1]" not in k}
+
+
+get_environment_proxies_orig = httpx._utils.get_environment_proxies
+httpx._utils.get_environment_proxies = get_environment_proxies
+httpx._client.get_environment_proxies = get_environment_proxies
+
+
 class ProxyResource:
     """
     Simple proxy resource that forwards incoming requests from the
@@ -136,26 +175,74 @@ class ProxyResource:
     def __init__(self, extension: ProxiedDockerContainerExtension):
         self.extension = extension
 
-    @route("/<path:path>")
-    def index(self, request: Request, path: str, *args, **kwargs):
-        return self._proxy_request(request, forward_path=f"/{path}")
+    def __call__(self, request, path, *args, **kwargs):
+        print("!CALL", request, path, type(request), request.__dict__)
+
+    # @route("/<path:path>")
+    # def index(self, request: Request, path: str, *args, **kwargs):
+    #     return self._proxy_request(request, forward_path=f"/{path}")
 
     def _proxy_request(self, request: Request, forward_path: str, *args, **kwargs):
         self.extension.start_container()
 
-        port = self.extension.container_ports[0]
-        container_host = get_addressable_container_host()
-        base_url = f"http://{container_host}:{port}"
+        print("!REQ", request, request.__dict__)
+        if request.environ.get("SERVER_PROTOCOL") == "HTTP/2":
+            return self._proxy_http2_request(request, forward_path=forward_path)
+
+        # create proxy
+        base_url = self._get_target_url(request)
         proxy = Proxy(forward_base_url=base_url)
 
         # update content length (may have changed due to content compression)
         if request.method not in ("GET", "OPTIONS"):
             request.headers["Content-Length"] = str(len(request.data))
 
-        # make sure we're forwarding the correct Host header
-        request.headers["Host"] = f"localhost:{port}"
+        # # make sure we're forwarding the correct Host header
+        # request.headers["Host"] = f"localhost:{port}"
 
         # forward the request to the target
         result = proxy.forward(request, forward_path=forward_path)
 
         return result
+
+    def _proxy_http2_request(
+        self, request: Request, forward_path: str, *args, **kwargs
+    ):
+        import traceback
+
+        print("!request in ls-ext", request)
+        print("".join(traceback.format_stack()))
+
+        with httpx.Client(http2=True, http1=False) as client:
+            target_url = f"{self._get_target_url(request)}{forward_path}"
+            print("!target_url", target_url)
+            response = client.request(
+                method=request.method,
+                url=target_url,
+                headers=request.headers,
+                content=request.data,
+            )
+            result = Response(
+                response=response.content,
+                status=response.status_code,
+                headers=dict(response.headers),
+            )
+            content = request.stream.read()
+            print(
+                "!response.headers",
+                dict(response.headers),
+                response.content,
+                response.status_code,
+                content,
+            )
+            # request.write(b'foo response')
+            # return result
+
+    def _get_target_url(self, request: Request) -> str:
+        port = self.extension.container_ports[0]
+        if self.extension.request_to_port_router:
+            port = self.extension.request_to_port_router(request)
+
+        container_host = get_addressable_container_host()
+        base_url = f"http://{container_host}:{port}"
+        return base_url

--- a/localstack-typedb/localstack_typedb/utils/h2_proxy.py
+++ b/localstack-typedb/localstack_typedb/utils/h2_proxy.py
@@ -1,0 +1,56 @@
+import socket
+
+from twisted.internet import reactor
+
+from localstack.utils.patch import patch
+from twisted.web._http2 import H2Connection
+
+
+class TcpForwarder:
+    """Simple helper class for bidirectional forwarding of TPC traffic."""
+
+    buffer_size = 1024
+
+    def __init__(self, port: int, host: str = "localhost"):
+        self.port = port
+        self.host = host
+        self._socket = None
+        self.connect()
+
+    def connect(self):
+        if not self._socket:
+            self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self._socket.connect((self.host, self.port))
+
+    def receive_loop(self, callback):
+        while True:
+            data = self._socket.recv(self.buffer_size)
+            callback(data)
+            if not data:
+                break
+
+    def send(self, data):
+        self._socket.sendall(data)
+
+
+def apply_http2_patches_for_grpc_support(target_port: int):
+    """
+    Apply some patches to proxy incoming gRPC requests and forward them to a target port.
+    Note: this is a very brute-force approach and needs to be fixed/enhanced over time!
+    """
+
+    @patch(H2Connection.connectionMade)
+    def _connectionMade(fn, self, *args, **kwargs):
+        def _process(data):
+            self.transport.write(data)
+
+        # TODO: make port configurable
+        self._ls_forwarder = TcpForwarder(target_port)
+        reactor.getThreadPool().callInThread(self._ls_forwarder.receive_loop, _process)
+
+    @patch(H2Connection.dataReceived)
+    def _dataReceived(fn, self, data, *args, **kwargs):
+        forwarder = getattr(self, "_ls_forwarder", None)
+        if not forwarder:
+            return fn(self, data, *args, **kwargs)
+        forwarder.send(data)

--- a/localstack-typedb/pyproject.toml
+++ b/localstack-typedb/pyproject.toml
@@ -14,6 +14,7 @@ authors = [
 keywords = ["LocalStack", "TypeDB"]
 classifiers = []
 dependencies = [
+    "httpx"
 ]
 
 [project.urls]
@@ -26,7 +27,8 @@ dev = [
     "localstack",
     "pytest",
     "rolo",
-    "ruff"
+    "ruff",
+    "typedb-driver",
 ]
 
 [project.entry-points."localstack.extensions"]

--- a/localstack-typedb/tests/test_extension.py
+++ b/localstack-typedb/tests/test_extension.py
@@ -1,8 +1,9 @@
 import requests
 from localstack.utils.strings import short_uid
+from typedb.driver import TypeDB, Credentials, DriverOptions, TransactionType
 
 
-def test_connect_to_db():
+def test_connect_to_db_via_http_api():
     host = "typedb.localhost.localstack.cloud:4566"
 
     # get auth token
@@ -35,3 +36,38 @@ def test_connect_to_db():
         headers={"Authorization": f"bearer {token}"},
     )
     assert response.ok
+
+
+def test_connect_to_db_via_grpc_endpoint():
+    # test taken from https://typedb.com/docs/drivers/2.x/python/
+
+    db_name = "access-management-db"
+    server_host = "typedb.localhost.localstack.cloud:4566"
+    # server_host = "localhost:1729"
+
+    driver_cfg = TypeDB.driver(
+        server_host,
+        Credentials("admin", "password"),
+        DriverOptions(is_tls_enabled=False),
+    )
+    with driver_cfg as driver:
+        if driver.databases.contains(db_name):
+            driver.databases.get(db_name).delete()
+        driver.databases.create(db_name)
+        print("!create driver transaction", driver, type(driver))
+        with driver.transaction(db_name, TransactionType.SCHEMA) as tx:
+            pass
+        #     tx.query("define person sub entity;").resolve()
+        #     tx.query(
+        #         "define name sub attribute, value string; person owns name;"
+        #     ).resolve()
+        #     tx.commit()
+        #
+        # with driver.transaction(db_name, TransactionType.WRITE) as tx:
+        #     tx.query("insert $p isa person, has name 'Alice';").resolve()
+        #     tx.query("insert $p isa person, has name 'Bob';").resolve()
+        #     tx.commit()
+        # with driver.transaction(db_name, TransactionType.READ) as tx:
+        #     results = tx.query("match $p isa person; fetch $p: name;").resolve()
+        #     for json in results:
+        #         print(json)

--- a/localstack-typedb/tests/test_extension.py
+++ b/localstack-typedb/tests/test_extension.py
@@ -39,11 +39,8 @@ def test_connect_to_db_via_http_api():
 
 
 def test_connect_to_db_via_grpc_endpoint():
-    # test taken from https://typedb.com/docs/drivers/2.x/python/
-
     db_name = "access-management-db"
     server_host = "typedb.localhost.localstack.cloud:4566"
-    # server_host = "localhost:1729"
 
     driver_cfg = TypeDB.driver(
         server_host,
@@ -54,20 +51,19 @@ def test_connect_to_db_via_grpc_endpoint():
         if driver.databases.contains(db_name):
             driver.databases.get(db_name).delete()
         driver.databases.create(db_name)
-        print("!create driver transaction", driver, type(driver))
+
         with driver.transaction(db_name, TransactionType.SCHEMA) as tx:
-            pass
-        #     tx.query("define person sub entity;").resolve()
-        #     tx.query(
-        #         "define name sub attribute, value string; person owns name;"
-        #     ).resolve()
-        #     tx.commit()
-        #
-        # with driver.transaction(db_name, TransactionType.WRITE) as tx:
-        #     tx.query("insert $p isa person, has name 'Alice';").resolve()
-        #     tx.query("insert $p isa person, has name 'Bob';").resolve()
-        #     tx.commit()
-        # with driver.transaction(db_name, TransactionType.READ) as tx:
-        #     results = tx.query("match $p isa person; fetch $p: name;").resolve()
-        #     for json in results:
-        #         print(json)
+            tx.query("define entity person;").resolve()
+            tx.query("define attribute name, value string; person owns name;").resolve()
+            tx.commit()
+
+        with driver.transaction(db_name, TransactionType.WRITE) as tx:
+            tx.query("insert $p isa person, has name 'Alice';").resolve()
+            tx.query("insert $p isa person, has name 'Bob';").resolve()
+            tx.commit()
+        with driver.transaction(db_name, TransactionType.READ) as tx:
+            results = tx.query(
+                'match $p isa person; fetch {"name": $p.name};'
+            ).resolve()
+            for json in results:
+                print(json)


### PR DESCRIPTION
Enable proxy forwarding for gRPC HTTP2 traffic for TypeDB. 

Currently following a very crude approach that intercepts *all* HTTP2 (gRPC) connections and forwards them to the TypeDB container enpoint, which obviously needs to be fixed and enhanced over time..